### PR TITLE
add started getter

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,6 +61,10 @@ class Simring {
     return this.manager.finished;
   }
 
+  get started() {
+    return this.manager.started;
+  }
+
   start(anotherUriList) {
     return this.manager.simring(anotherUriList);
   }


### PR DESCRIPTION
for those of us that start the simringer later and not at instantiation

means that I can check if its started or not (ie whether I call `addUri` or `start`)