### PR TITLE
expect a b2bua to pass these caller/callee details along

### DIFF
--- a/lib/call-manager.js
+++ b/lib/call-manager.js
@@ -23,6 +23,14 @@ class CallManager extends Emitter {
     this.callAnswered = false;
     this.bridged = false;
     this.callTimeout = this.callOpts.timeout || DEFAULT_TIMEOUT;
+
+    if (!(this.callOpts.headers && this.callOpts.headers.from) && !this.callOpts.callingNumber) {
+      this.callOpts.callingNumber = opts.req.callingNumber;
+    }
+    if (!(this.callOpts.headers && this.callOpts.headers.to) && !this.callOpts.calledNumber) {
+      this.callOpts.calledNumber = opts.req.calledNumber;
+    }
+
     this.req.on('cancel', () => {
       this._logger.info(`caller hung up, terminating ${this.cip.size} calls in progress`);
       this.callerGone = true;


### PR DESCRIPTION
this is essentially a b2bua so i still expect to have the caller and calling information passed on by default if we havent provided our own - as the b2bua function in drachtio-srf does.

(I havent tested this commit out personally yet)