### PR TITLE
Fixed bug requireing proxyResponseHeaders to be defined

### DIFF
--- a/lib/call-manager.js
+++ b/lib/call-manager.js
@@ -181,11 +181,13 @@ class CallManager extends Emitter {
 
   copyUACHeadersToUAS(uacRes) {
     this.callOpts.headers = {} ;
-    this.callOpts.proxyResponseHeaders.forEach((hdr) => {
-      if (uacRes.has(hdr)) {
-        this.callOpts[hdr] = uacRes.get(hdr) ;
-      }
-    });
+    if(this.callOpts.proxyResponseHeaders) {
+      this.callOpts.proxyResponseHeaders.forEach((hdr) => {
+        if (uacRes.has(hdr)) {
+          this.callOpts[hdr] = uacRes.get(hdr) ;
+        }
+      });
+    }
 
     // after copying headers from A to B, apply any specific requested headerss
     if (typeof this.callOpts.responseHeaders === 'function') {


### PR DESCRIPTION
Fixes bug where the code would error out unless callOpts include proxyResponseHeaders: []