### PR TITLE
Cancel timeout handle on finalFailure

### DIFF
--- a/lib/call-manager.js
+++ b/lib/call-manager.js
@@ -145,6 +145,7 @@ class CallManager extends Emitter {
       })
       .catch((err) => {
         this.emit('finalFailure');
+        if (timer) clearTimeout(timer);
         if (!this.callerGone) {
           this._logger.info(`CallManager#attemptOne: call to ${uri} failed with ${err.status}`);
         }


### PR DESCRIPTION
I think this bug will only manifest itself if SRF is used in outbound connection mode.

If simring is used, but everyone rejects the call, then this timer will fire after the srf session has been ended, causing the node.js app to crash out.

Cancelling it finalError seems like the appropriate thing to do(?)