### PR TITLE
Cancel reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # drachtio-fn-b2b-sugar
 
+## :bell: :bell: Warning :bell: :bell:
+drachtio-fn-b2b-sugar now gives reasons on cancellations. In order to support that you need to use a version of drachtip-srf above 4.4.21
+If you try to use this module without using the correct version of drachtio-srf you will get rejected promises due to errors from within drachtio-srf
+
 A selection of useful and reusable functions dealing with common [B2BUA](https://drachtio.org/api#srf-create-b2bua) scenarios for the [drachtio](https://drachtio.org) SIP server.
 
 ## simring function

--- a/lib/call-manager.js
+++ b/lib/call-manager.js
@@ -173,7 +173,15 @@ class CallManager extends Emitter {
       }
       else {
         this._logger.info(`killing call to ${uri}`);
-        req.cancel();
+        if (this.callAnswered) {
+          req.cancel({
+            headers: {
+              'Reason': 'SIP;cause=200;text="Call completed elsewhere"'
+            }
+          });
+        } else {
+          req.cancel();
+        }
       }
     }
     this.cip.clear();

--- a/lib/call-manager.js
+++ b/lib/call-manager.js
@@ -31,10 +31,10 @@ class CallManager extends Emitter {
       this.callOpts.calledNumber = opts.req.calledNumber;
     }
 
-    this.req.on('cancel', () => {
+    this.req.on('cancel', (res) => {
       this._logger.info(`caller hung up, terminating ${this.cip.size} calls in progress`);
       this.callerGone = true;
-      this.killCalls();
+      this.killCalls(null, res.has('Reason') ? res.get('Reason') : null);
     });
 
     // this is the Promise we resolve when the simring finally concludes
@@ -163,7 +163,7 @@ class CallManager extends Emitter {
     return p;
   }
 
-  killCalls(spareMe) {
+  killCalls(spareMe, reason) {
     for (const arr of this.cip) {
       const uri = arr[0];
       const req = arr[1];
@@ -173,10 +173,15 @@ class CallManager extends Emitter {
       }
       else {
         this._logger.info(`killing call to ${uri}`);
-        if (this.callAnswered) {
+
+        if (!reason && this.callAnswered) {
+          reason = 'SIP;cause=200;text="Call completed elsewhere"';
+        }
+
+        if (reason) {
           req.cancel({
             headers: {
-              'Reason': 'SIP;cause=200;text="Call completed elsewhere"'
+              'Reason': reason
             }
           });
         } else {

--- a/lib/call-manager.js
+++ b/lib/call-manager.js
@@ -34,7 +34,7 @@ class CallManager extends Emitter {
     this.req.on('cancel', (res) => {
       this._logger.info(`caller hung up, terminating ${this.cip.size} calls in progress`);
       this.callerGone = true;
-      this.killCalls(null, res.has('Reason') ? res.get('Reason') : null);
+      this.killCalls(null, res && res.has('Reason') ? res.get('Reason') : null);
     });
 
     // this is the Promise we resolve when the simring finally concludes

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "author": "Dave Horton",
   "license": "MIT",
   "peerDependencies": {
-    "drachtio-srf": "^4.4.x"
+    "drachtio-srf": "^4.4.21"
   },
   "devDependencies": {
-    "drachtio-srf": "^4.4.8"
+    "drachtio-srf": "^4.4.21"
   }
 }


### PR DESCRIPTION
Enable cancel reasons to be propagated from the original request in

Enable us sending our own reason if the call was answered by a different leg in the fork.

I had issues getting the propagation working @davehorton - should res be available where I expect it to in the cancel listener?