### PR TITLE
If simringer receives a 180 on a branch then propagate 180 back out of simringer

### DIFF
--- a/lib/call-manager.js
+++ b/lib/call-manager.js
@@ -23,6 +23,7 @@ class CallManager extends Emitter {
     this.callAnswered = false;
     this.bridged = false;
     this.callTimeout = this.callOpts.timeout || DEFAULT_TIMEOUT;
+    this.forward180 = true;
 
     if (!(this.callOpts.headers && this.callOpts.headers.from) && !this.callOpts.callingNumber) {
       this.callOpts.callingNumber = opts.req.callingNumber;
@@ -114,6 +115,12 @@ class CallManager extends Emitter {
           if (this.notifiers.cbProvisional) this.notifiers.cbProvisional(response);
           if (this.strategy === 'hunt' && [180, 183].includes(response.status) && response.body) {
             // TODO: cut through audio on early media..
+          }
+          if (response.status === 180 && this.forward180) {
+            // Got a ringing from a client; send a 180 upstream
+            this._logger.debug({response}, 'Branch sent 180 - sending 180 upstream to keep them hopeful');
+            this.res.send(180);
+            this.forward180 = false;
           }
         }
       })


### PR DESCRIPTION
Only does so for the first branch to send back a 180.

Didn't deal with other 1xxs, especially 183.  But using simringer to call a bunch of endpoint devices must be a common case and most will send 180 and not 183.

Wanted this since at the moment if a call is being processed through simringer there is no progress (180 Ringing) and that creates uncomfortable dead air for the call who is likely to conclude that the call failed.