### PR TITLE
Forward cancellation reason in simring

### DIFF
--- a/lib/call-manager.js
+++ b/lib/call-manager.js
@@ -126,7 +126,7 @@ class CallManager extends Emitter {
         }
         this.callAnswered = true;
         uac = dlg;
-        this.killCalls(uri, 'SIP;cause=200;text="Call completed elsewhere');
+        this.killCalls(uri, 'SIP;cause=200;text="Call completed elsewhere"');
         this.cip.delete(uri);
         if (timer) clearTimeout(timer);
 


### PR DESCRIPTION
Forwards incoming Reason header when a cancel is received, for goodness such as answered elsewhere.